### PR TITLE
Fix MultiVariateNormalDiag and similar distributions not being properly Jittable.

### DIFF
--- a/distrax/_src/bijectors/diag_linear.py
+++ b/distrax/_src/bijectors/diag_linear.py
@@ -57,11 +57,21 @@ class DiagLinear(linear.Linear):
         batch_shape=diag.shape[:-1],
         dtype=diag.dtype)
     self._diag = diag
-    self.forward = self._bijector.forward
-    self.forward_log_det_jacobian = self._bijector.forward_log_det_jacobian
-    self.inverse = self._bijector.inverse
-    self.inverse_log_det_jacobian = self._bijector.inverse_log_det_jacobian
-    self.inverse_and_log_det = self._bijector.inverse_and_log_det
+
+  def forward(self, x: Array) -> Array:
+    return self._bijector.forward(x)
+
+  def forward_log_det_jacobian(self, x: Array) -> Array:
+    return self._bijector.forward_log_det_jacobian(x)
+
+  def inverse(self, y: Array) -> Array:
+    return self._bijector.inverse(y)
+
+  def inverse_log_det_jacobian(self, y: Array) -> Array:
+    return self._bijector.inverse_log_det_jacobian(y)
+
+  def inverse_and_log_det(self, y: Array) -> Tuple[Array, Array]:
+    return self._bijector.inverse_and_log_det(y)
 
   @property
   def diag(self) -> Array:

--- a/distrax/_src/bijectors/diag_plus_low_rank_linear.py
+++ b/distrax/_src/bijectors/diag_plus_low_rank_linear.py
@@ -201,11 +201,21 @@ class DiagPlusLowRankLinear(linear.Linear):
     self._diag = diag
     self._u_matrix = u_matrix
     self._v_matrix = v_matrix
-    self.forward = self._bijector.forward
-    self.forward_log_det_jacobian = self._bijector.forward_log_det_jacobian
-    self.inverse = self._bijector.inverse
-    self.inverse_log_det_jacobian = self._bijector.inverse_log_det_jacobian
-    self.inverse_and_log_det = self._bijector.inverse_and_log_det
+
+  def forward(self, x: Array) -> Array:
+    return self._bijector.forward(x)
+
+  def forward_log_det_jacobian(self, x: Array) -> Array:
+    return self._bijector.forward_log_det_jacobian(x)
+
+  def inverse(self, y: Array) -> Array:
+    return self._bijector.inverse(y)
+
+  def inverse_log_det_jacobian(self, y: Array) -> Array:
+    return self._bijector.inverse_log_det_jacobian(y)
+
+  def inverse_and_log_det(self, y: Array) -> Tuple[Array, Array]:
+    return self._bijector.inverse_and_log_det(y)
 
   @property
   def diag(self) -> Array:


### PR DESCRIPTION
Currently, `MultiVariateNormalDiag` and other such distributions that depend on the `DiagLinear` and `DiagPlusLowRankLinear` distributions are not jittable (see #230).

This means that they cannot be returned from jitted functions. This is a bug because these distributions and bijectors all inherit from `Jittable` and yet are not able to be used as inputs or outputs of such functions as intended.

The issue is that these bijectors attempt to "inherit" from their internal `_bijector` objects by doing the following in their `__init__` method:
```py
self.forward = self._bijector.forward
```

However, I found that this actually creates a closure over `self._bijector` at trace time which in turn leaks the tracer held within `self._bijector`. Simply implementing the corresponding functions that at call-time access `self._bijector` fixes the issue.