### PR TITLE
CVE-2023-33976 - Bump TF requirement to 2.13+

### DIFF
--- a/requirements/requirements-examples.txt
+++ b/requirements/requirements-examples.txt
@@ -1,4 +1,4 @@
-tensorflow>=2.4.0
+tensorflow>=2.13.0
 tensorflow-datasets>=4.2.0
 dm-haiku>=0.0.3
 optax>=0.0.6


### PR DESCRIPTION
CVE-2023-33976 - Bump TF requirement to 2.13+

https://nvd.nist.gov/vuln/detail/CVE-2023-33976

Shall we try all the way up to 2.20 ? (https://blog.tensorflow.org/2025/08/whats-new-in-tensorflow-2-20.html)

https://www.cve.org/CVERecord/SearchResults?query=tensorflow