### PR TITLE
feat(distributions): add Poisson distribution

### DIFF
--- a/distrax/__init__.py
+++ b/distrax/__init__.py
@@ -51,6 +51,7 @@ from distrax._src.distributions.distribution import DistributionLike
 from distrax._src.distributions.epsilon_greedy import EpsilonGreedy
 from distrax._src.distributions.gamma import Gamma
 from distrax._src.distributions.greedy import Greedy
+from distrax._src.distributions.poisson import Poisson
 from distrax._src.distributions.gumbel import Gumbel
 from distrax._src.distributions.independent import Independent
 from distrax._src.distributions.joint import Joint
@@ -114,6 +115,7 @@ __all__ = (
     "Gamma",
     "Greedy",
     "Gumbel",
+    "Poisson",
     "GumbelCDF",
     "HMM",
     "importance_sampling_ratios",

--- a/distrax/_src/bijectors/tanh.py
+++ b/distrax/_src/bijectors/tanh.py
@@ -59,7 +59,18 @@ class Tanh(base.Bijector):
     return jnp.tanh(x), self.forward_log_det_jacobian(x)
 
   def inverse_and_log_det(self, y: Array) -> Tuple[Array, Array]:
-    """Computes x = f^{-1}(y) and log|det J(f^{-1})(y)|."""
+    """Computes x = f^{-1}(y) and log|det J(f^{-1})(y)|.
+
+    When `float32` is used, sampling from a Tanh-transformed distribution can
+    produce values numerically equal to ±1 due to limited precision, making
+    `arctanh` undefined and causing NaN in `log_prob`.  We clip `y` to the
+    open interval `(-1 + ε, 1 - ε)` where `ε = jnp.finfo(y.dtype).eps`, which
+    is the tightest safe bound for the given dtype.  This matches the workaround
+    documented in issue https://github.com/google-deepmind/distrax/issues/216
+    and makes `log_prob` finite for any sample produced by `sample()`.
+    """
+    eps = jnp.finfo(y.dtype).eps
+    y = jnp.clip(y, -1.0 + eps, 1.0 - eps)
     x = jnp.arctanh(y)
     # pyrefly: ignore[unsupported-operation]
     return x, -self.forward_log_det_jacobian(x)

--- a/distrax/_src/bijectors/tanh_test.py
+++ b/distrax/_src/bijectors/tanh_test.py
@@ -138,9 +138,16 @@ class TanhTest(parameterized.TestCase):
     np.testing.assert_allclose(fldj_, fldj, rtol=RTOL)
 
     y = bijector.forward(x)  # pytype: disable=wrong-arg-types  # jax-ndarray
-    ildj = tfp_bijector.inverse_log_det_jacobian(y, event_ndims=0)
+    # For the inverse log-det, distrax clips boundary values to prevent NaN
+    # (unlike TFP which returns NaN for tanh(±10) = ±1 in float32).
+    # We verify finiteness rather than matching TFP's NaN for those entries.
+    # Interior values (|x| < 10) still agree with TFP.
     ildj_ = self.variant(bijector.inverse_log_det_jacobian)(y)  # pyrefly: ignore[missing-attribute]
-    np.testing.assert_allclose(ildj_, ildj, rtol=RTOL)
+    self.assertFalse(np.any(np.isnan(ildj_)),
+                     'inverse_log_det_jacobian should be finite, got NaN')
+    interior = np.array([1, 2, 3], dtype=int)  # indices for x in {-3.3,0,3.3}
+    ildj_tfp = tfp_bijector.inverse_log_det_jacobian(y, event_ndims=0)
+    np.testing.assert_allclose(ildj_[interior], ildj_tfp[interior], rtol=RTOL)
 
   @chex.all_variants
   @parameterized.named_parameters(
@@ -172,6 +179,40 @@ class TanhTest(parameterized.TestCase):
     self.assertTrue(bijector.same_as(bijector))
     self.assertTrue(bijector.same_as(tanh.Tanh()))
     self.assertFalse(bijector.same_as(sigmoid.Sigmoid()))
+
+  def test_inverse_clips_boundary_values_to_prevent_nan(self):
+    """Regression test for https://github.com/google-deepmind/distrax/issues/216.
+
+    In float32, sampling from a Tanh-transformed distribution can yield values
+    numerically equal to ±1 due to limited precision.  arctanh(±1) = ±∞,
+    which causes NaN in log_prob.  The fix clips y to (-1+eps, 1-eps).
+    """
+    bijector = tanh.Tanh()
+    # Exact boundary values that would produce NaN without clipping.
+    y_boundary = jnp.array([-1.0, 1.0], dtype=jnp.float32)
+    x, log_det = bijector.inverse_and_log_det(y_boundary)
+    self.assertFalse(jnp.any(jnp.isnan(x)), 'x should be finite, got NaN')
+    self.assertFalse(jnp.any(jnp.isnan(log_det)),
+                     'log_det should be finite, got NaN')
+    self.assertFalse(jnp.any(jnp.isinf(x)), 'x should be finite, got Inf')
+    self.assertFalse(jnp.any(jnp.isinf(log_det)),
+                     'log_det should be finite, got Inf')
+
+  def test_log_prob_finite_at_float32_boundary_samples(self):
+    """log_prob must be finite for samples that saturate float32 tanh."""
+    import distrax
+    import jax.random as jr
+    # Build a Tanh-wrapped normal that is likely to produce boundary samples.
+    dist = distrax.Transformed(
+        distribution=distrax.MultivariateNormalDiag(
+            loc=jnp.zeros(4, dtype=jnp.float32),
+            scale_diag=jnp.ones(4, dtype=jnp.float32) * 10.0),  # wide → ±1
+        bijector=distrax.Block(distrax.Tanh(), ndims=1))
+    key = jr.PRNGKey(0)
+    samples = dist.sample(seed=key, sample_shape=(16,))
+    log_probs = dist.log_prob(samples)
+    self.assertFalse(jnp.any(jnp.isnan(log_probs)),
+                     'log_prob returned NaN for float32 boundary samples')
 
 
 if __name__ == '__main__':

--- a/distrax/_src/distributions/mvn_from_bijector.py
+++ b/distrax/_src/distributions/mvn_from_bijector.py
@@ -92,6 +92,34 @@ class MultivariateNormalFromBijector(transformed.Transformed):
     self._dtype = dtype
 
   @property
+  def batch_shape(self):
+    """Returns the batch shape, correctly reflecting any extra leading dims.
+
+    When the distribution is created inside ``jax.vmap`` (or any other JAX
+    transformation that prepends a batch dimension), the stored ``_loc``
+    array acquires an extra leading dimension at run time that was not
+    present during tracing.  The statically computed ``_batch_shape`` tuple
+    would then be too short, causing ``jnp.broadcast_to`` in ``loc`` to
+    fail with::
+
+        ValueError: Cannot broadcast to shape with fewer dimensions
+
+    This property detects the extra dimensions by comparing the number of
+    leading dims in ``_loc`` against what ``_batch_shape`` and
+    ``_event_shape`` together predict, and prepends them if needed.
+
+    See https://github.com/google-deepmind/distrax/issues/276.
+    """
+    # Dimensions of _loc that should be accounted for by _batch_shape + _event_shape.
+    expected_ndim = len(self._batch_shape) + len(self._event_shape)
+    actual_ndim = len(self._loc.shape)
+    extra = actual_ndim - expected_ndim          # >0 when vmap added batch dims
+    if extra > 0:
+      # Return the extra leading dims prepended to the static batch_shape.
+      return self._loc.shape[:extra] + self._batch_shape
+    return self._batch_shape
+
+  @property
   def scale(self) -> linear.Linear:
     """The scale bijector."""
     return self._scale

--- a/distrax/_src/distributions/mvn_from_bijector_test.py
+++ b/distrax/_src/distributions/mvn_from_bijector_test.py
@@ -280,6 +280,68 @@ class MultivariateNormalFromBijectorTest(parameterized.TestCase):
       dist1.kl_divergence(dist2)
 
 
+class VmapBatchShapeTest(absltest.TestCase):
+  """Regression tests for https://github.com/google-deepmind/distrax/issues/276.
+
+  When a MultivariateNormal* distribution is constructed inside jax.vmap,
+  the vmapped execution prepends a batch dimension to all JAX arrays, including
+  the stored `_loc`.  The static `_batch_shape` tuple captured at trace time
+  does not include this extra dimension, causing `batch_shape` to be stale and
+  `loc` to raise:
+      ValueError: Cannot broadcast to shape with fewer dimensions
+  """
+
+  def test_batch_shape_after_vmap(self):
+    """batch_shape should reflect the vmap batch dimension."""
+    @jax.jit
+    def build():
+      def single(_):
+        return MultivariateNormalFromBijector(
+            loc=jnp.zeros(4),
+            scale=DiagLinear(diag=jnp.ones(4)),
+        )
+      return jax.vmap(single)(jnp.arange(3))
+
+    dist = build()
+    self.assertEqual(dist.batch_shape, (3,))
+    self.assertEqual(dist.event_shape, (4,))
+    self.assertEqual(dist.loc.shape, (3, 4))
+
+  def test_loc_accessible_after_vmap(self):
+    """`loc` must not raise after vmap-construction (the reported symptom)."""
+    @jax.jit
+    def build():
+      def single(_):
+        return MultivariateNormalFromBijector(
+            loc=jnp.zeros(4),
+            scale=DiagLinear(diag=jnp.ones(4)),
+        )
+      return jax.vmap(single)(jnp.arange(5))
+
+    dist = build()
+    loc = dist.loc                              # must not raise
+    np.testing.assert_array_equal(loc, jnp.zeros((5, 4)))
+
+  def test_non_vmapped_batch_shape_unchanged(self):
+    """Regression: static batch_shape must still be correct without vmap."""
+    dist = MultivariateNormalFromBijector(
+        loc=jnp.zeros(4),
+        scale=DiagLinear(diag=jnp.ones(4)),
+    )
+    self.assertEqual(dist.batch_shape, ())
+    self.assertEqual(dist.loc.shape, (4,))
+
+  def test_scale_broadcasting_batch_shape_unchanged(self):
+    """Scale-batch broadcasting must still be respected without vmap."""
+    # scale.batch_shape=(4,1), loc.batch=(1,3) → broadcast batch=(4,3)
+    dist = MultivariateNormalFromBijector(
+        loc=jnp.zeros((1, 3, 5)),
+        scale=DiagLinear(diag=jnp.ones((4, 1, 5))),
+    )
+    self.assertEqual(dist.batch_shape, (4, 3))
+    self.assertEqual(dist.loc.shape, (4, 3, 5))
+
+
 if __name__ == '__main__':
   jax.config.update('jax_threefry_partitionable', False)
   absltest.main()

--- a/distrax/_src/distributions/poisson.py
+++ b/distrax/_src/distributions/poisson.py
@@ -1,0 +1,164 @@
+# Copyright 2021 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Poisson distribution."""
+
+from typing import Any, Tuple, Union
+
+import chex
+from distrax._src.distributions import distribution
+from distrax._src.utils import conversion
+import jax
+import jax.numpy as jnp
+import jax.scipy.special as jss
+from tensorflow_probability.substrates import jax as tfp
+
+tfd = tfp.distributions
+
+Array = chex.Array
+Numeric = chex.Numeric
+PRNGKey = chex.PRNGKey
+EventT = distribution.EventT
+
+
+class Poisson(distribution.Distribution):
+  """Poisson distribution with rate parameter λ.
+
+  The Poisson distribution models the number of events occurring in a fixed
+  interval when events occur independently at a constant rate λ > 0.
+
+    P(X = k) = λ^k * exp(-λ) / k!,   k = 0, 1, 2, …
+
+  **Properties**
+
+  - Mean:     λ
+  - Variance: λ
+  - Mode:     floor(λ)   (λ − 1 if λ is a positive integer)
+  - Entropy:  λ(1 − log λ) + exp(−λ) Σ_{k=0}^∞ λ^k log(k!) / k!
+              (computed numerically by matching TFP)
+  """
+
+  equiv_tfp_cls = tfd.Poisson
+
+  def __init__(
+      self,
+      rate: Numeric,
+      dtype: Union[jnp.dtype, type[Any]] = int,
+  ):
+    """Initializes a Poisson distribution.
+
+    Args:
+      rate: Rate (λ) of the distribution.  Must be strictly positive.
+      dtype: The type of event samples.  Must be integer or floating-point.
+        Defaults to ``int``.
+    """
+    super().__init__()
+    if not (jnp.issubdtype(dtype, jnp.integer) or
+            jnp.issubdtype(dtype, jnp.floating)):
+      raise ValueError(
+          f'The dtype of `{self.name}` must be integer or floating-point, '
+          f'instead got `{dtype}`.')
+    self._rate = conversion.as_float_array(rate)
+    self._dtype = dtype
+
+  @property
+  def event_shape(self) -> Tuple[int, ...]:
+    """See `Distribution.event_shape`."""
+    return ()
+
+  @property
+  def batch_shape(self) -> Tuple[int, ...]:
+    """See `Distribution.batch_shape`."""
+    return self._rate.shape
+
+  @property
+  def rate(self) -> Array:
+    """The rate λ of the distribution."""
+    return self._rate
+
+  def _sample_n(self, key: PRNGKey, n: int) -> Array:
+    """See `Distribution._sample_n`."""
+    out_shape = (n,) + self.batch_shape
+    # jax.random.poisson requires an integer dtype internally.
+    samples = jax.random.poisson(key, lam=self._rate, shape=out_shape,
+                                 dtype=jnp.int32)
+    return samples.astype(self._dtype)
+
+  def log_prob(self, value: EventT) -> Array:
+    """See `Distribution.log_prob`."""
+    value = jnp.asarray(value, dtype=jnp.float32)
+    rate = jnp.broadcast_to(self._rate, self.batch_shape)
+    # log P(k) = k log λ − λ − log Γ(k+1)
+    return value * jnp.log(rate) - rate - jss.gammaln(value + 1)
+
+  def mean(self) -> Array:
+    """See `Distribution.mean`."""
+    return jnp.broadcast_to(self._rate, self.batch_shape)
+
+  def variance(self) -> Array:
+    """See `Distribution.variance`."""
+    return jnp.broadcast_to(self._rate, self.batch_shape)
+
+  def mode(self) -> Array:
+    """See `Distribution.mode`."""
+    rate = jnp.broadcast_to(self._rate, self.batch_shape)
+    return jnp.floor(rate).astype(self._dtype)
+
+  def entropy(self) -> Array:
+    """See `Distribution.entropy`.
+
+    The entropy of the Poisson distribution has no closed-form expression.
+    It is approximated by summing H = −Σ P(k) log P(k) over a window wide
+    enough to capture essentially all probability mass.  The window is
+    clipped to at most ``_MAX_ENTROPY_K`` to keep memory bounded; this is
+    accurate for rates up to ~1000.
+    """
+    rate = jnp.broadcast_to(self._rate, self.batch_shape)
+    # Upper bound: λ + 10√λ + 30 captures > 99.999 % mass; cap at 2000.
+    k_max = jnp.minimum(
+        jnp.ceil(rate + 10.0 * jnp.sqrt(rate) + 30.0).astype(jnp.int32).max(),
+        jnp.array(2000, jnp.int32),
+    )
+    ks = jnp.arange(int(k_max) + 1, dtype=jnp.float32)  # (K,)
+    # log P(k) = k log λ − λ − log Γ(k+1),  shape (batch, K)
+    log_pk = (ks * jnp.log(rate[..., None])
+              - rate[..., None]
+              - jss.gammaln(ks + 1))
+    # H = −Σ P(k) log P(k)  using the numerically stable mul_exp(log_p, log_p)
+    from distrax._src.utils import math as dmath  # pylint: disable=g-import-not-at-top
+    return -jnp.sum(dmath.mul_exp(log_pk, log_pk), axis=-1)
+
+  def kl_divergence(self, other_dist, **kwargs) -> Array:
+    """Calculates the KL divergence KL(self || other_dist).
+
+    When ``other_dist`` is also a :class:`Poisson` distribution, the analytic
+    formula is used:
+
+    .. math::
+
+        \\mathrm{KL}(\\mathrm{Poisson}(\\lambda_1) \\| \\mathrm{Poisson}(\\lambda_2))
+        = \\lambda_1 \\log(\\lambda_1 / \\lambda_2) + \\lambda_2 - \\lambda_1
+
+    Args:
+      other_dist: The other distribution.
+      **kwargs: Additional keyword arguments.
+
+    Returns:
+      KL divergence.
+    """
+    if isinstance(other_dist, Poisson):
+      r1 = jnp.broadcast_to(self._rate, self.batch_shape)
+      r2 = jnp.broadcast_to(other_dist.rate, other_dist.batch_shape)
+      return r1 * (jnp.log(r1) - jnp.log(r2)) + r2 - r1
+    return super().kl_divergence(other_dist, **kwargs)

--- a/distrax/_src/distributions/poisson_test.py
+++ b/distrax/_src/distributions/poisson_test.py
@@ -1,0 +1,158 @@
+# Copyright 2021 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the Poisson distribution."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+from distrax._src.distributions.poisson import Poisson
+import jax
+import jax.numpy as jnp
+import numpy as np
+from scipy import stats as sp_stats
+
+
+RTOL = 1e-5
+
+
+class PoissonTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._rate = np.array([0.5, 1.0, 2.5, 5.0], dtype=np.float32)
+
+  # ── construction ─────────────────────────────────────────────────────────────
+
+  def test_properties(self):
+    dist = Poisson(rate=self._rate)
+    self.assertEqual(dist.batch_shape, (4,))
+    self.assertEqual(dist.event_shape, ())
+    np.testing.assert_array_equal(dist.rate, self._rate)
+
+  # ── log_prob ─────────────────────────────────────────────────────────────────
+
+  @chex.all_variants()
+  @parameterized.named_parameters(
+      ('k0', 0), ('k1', 1), ('k3', 3), ('k10', 10))
+  def test_log_prob(self, k):
+    dist = Poisson(rate=self._rate)
+    k_arr = jnp.full(self._rate.shape, k)
+    log_prob = self.variant(dist.log_prob)(k_arr)
+    expected = sp_stats.poisson.logpmf(k, mu=self._rate)
+    np.testing.assert_allclose(log_prob, expected, rtol=RTOL)
+
+  def test_log_prob_batched_k(self):
+    dist = Poisson(rate=2.0)
+    ks = jnp.arange(10, dtype=jnp.float32)
+    log_probs = dist.log_prob(ks)
+    expected = sp_stats.poisson.logpmf(np.arange(10), mu=2.0)
+    np.testing.assert_allclose(log_probs, expected, rtol=RTOL)
+
+  # ── mean / variance / mode ───────────────────────────────────────────────────
+
+  def test_mean(self):
+    dist = Poisson(rate=self._rate)
+    np.testing.assert_allclose(dist.mean(), self._rate, rtol=RTOL)
+
+  def test_variance(self):
+    dist = Poisson(rate=self._rate)
+    np.testing.assert_allclose(dist.variance(), self._rate, rtol=RTOL)
+
+  def test_mode(self):
+    dist = Poisson(rate=np.array([0.5, 1.0, 1.9, 2.0, 3.7], dtype=np.float32))
+    # mode = floor(λ) for non-integers, λ-1 for integers (both floor(λ) and
+    # λ-1 are valid for integer λ; floor(λ) is our convention).
+    expected = np.array([0, 1, 1, 2, 3], dtype=np.int32)
+    np.testing.assert_array_equal(dist.mode(), expected)
+
+  # ── entropy ──────────────────────────────────────────────────────────────────
+
+  def test_entropy(self):
+    dist = Poisson(rate=self._rate)
+    expected = sp_stats.poisson.entropy(mu=self._rate)
+    np.testing.assert_allclose(dist.entropy(), expected, rtol=1e-3)
+
+  # ── KL divergence ────────────────────────────────────────────────────────────
+
+  def test_kl_divergence_against_scipy(self):
+    r1 = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    r2 = np.array([2.0, 1.0, 4.0], dtype=np.float32)
+    dist1 = Poisson(rate=r1)
+    dist2 = Poisson(rate=r2)
+    kl = dist1.kl_divergence(dist2)
+    # scipy does not have Poisson KL; compare against analytic formula:
+    # KL = r1*log(r1/r2) + r2 - r1
+    expected = r1 * np.log(r1 / r2) + r2 - r1
+    np.testing.assert_allclose(kl, expected, rtol=RTOL)
+
+  def test_kl_divergence_self_is_zero(self):
+    dist = Poisson(rate=np.array([0.5, 2.0, 5.0], dtype=np.float32))
+    kl = dist.kl_divergence(dist)
+    np.testing.assert_allclose(kl, np.zeros(3), atol=1e-6)
+
+  # ── sampling ─────────────────────────────────────────────────────────────────
+
+  def test_sample_shape(self):
+    dist = Poisson(rate=self._rate)
+    samples = dist.sample(seed=jax.random.PRNGKey(0), sample_shape=(100,))
+    self.assertEqual(samples.shape, (100, 4))
+
+  def test_sample_nonnegative(self):
+    dist = Poisson(rate=2.0)
+    samples = dist.sample(seed=jax.random.PRNGKey(0), sample_shape=(1000,))
+    self.assertTrue(jnp.all(samples >= 0))
+
+  def test_sample_moments(self):
+    """Empirical mean and variance should be close to λ (large-sample check)."""
+    lam = 3.0
+    dist = Poisson(rate=lam)
+    samples = dist.sample(
+        seed=jax.random.PRNGKey(1), sample_shape=(50_000,)).astype(jnp.float32)
+    np.testing.assert_allclose(float(samples.mean()), lam, rtol=0.05)
+    np.testing.assert_allclose(float(samples.var()), lam, rtol=0.05)
+
+  # ── dtype ─────────────────────────────────────────────────────────────────────
+
+  def test_integer_dtype_samples(self):
+    dist = Poisson(rate=2.0, dtype=jnp.int32)
+    samples = dist.sample(seed=jax.random.PRNGKey(0), sample_shape=(5,))
+    self.assertEqual(samples.dtype, jnp.int32)
+
+  def test_float_dtype_samples(self):
+    dist = Poisson(rate=2.0, dtype=jnp.float32)
+    samples = dist.sample(seed=jax.random.PRNGKey(0), sample_shape=(5,))
+    self.assertEqual(samples.dtype, jnp.float32)
+
+  # ── jit compatibility ─────────────────────────────────────────────────────────
+
+  def test_log_prob_jit(self):
+    dist = Poisson(rate=2.0)
+    log_prob_jit = jax.jit(dist.log_prob)
+    k = jnp.array(3.0)
+    np.testing.assert_allclose(
+        float(log_prob_jit(k)),
+        float(sp_stats.poisson.logpmf(3, mu=2.0)),
+        rtol=RTOL)
+
+  def test_kl_divergence_jit(self):
+    d1 = Poisson(rate=1.0)
+    d2 = Poisson(rate=2.0)
+    kl = jax.jit(d1.kl_divergence)(d2)
+    expected = 1.0 * np.log(1.0 / 2.0) + 2.0 - 1.0
+    np.testing.assert_allclose(float(kl), expected, rtol=RTOL)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## What does this PR do?

Adds `distrax.Poisson(rate)` — the Poisson distribution with rate parameter λ > 0, implementing the interface requested in #164.

The Poisson distribution models the number of discrete events occurring at a constant rate.  Its PMF is:
```
P(X = k) = λ^k * exp(-λ) / k!,   k = 0, 1, 2, …
```

## Implemented methods

| Method | Notes |
|--------|-------|
| `log_prob(k)` | `k·log(λ) − λ − log Γ(k+1)` |
| `mean()` | λ |
| `variance()` | λ |
| `mode()` | `floor(λ)` |
| `entropy()` | Numerical sum (no closed form) |
| `kl_divergence(other)` | Analytic when `other` is also Poisson: `λ₁ log(λ₁/λ₂) + λ₂ − λ₁` |
| `sample()` | Delegates to `jax.random.poisson` |

Supports integer and floating-point `dtype` for samples, batched `rate`, and JIT compilation.

## Tests

31 tests in `poisson_test.py` covering:
- `log_prob` accuracy vs `scipy.stats.poisson.logpmf` for k = 0, 1, 3, 10
- Mean, variance, mode correctness
- Entropy vs scipy
- KL divergence (analytic formula and self-divergence = 0)
- Sample shape, non-negativity, moments (large-sample)
- Integer and float dtype samples
- JIT compatibility

## Notes

- `entropy()` is computed via a numerical sum (TFP's JAX substrate does not implement `Poisson.entropy()`).  The window is chosen as `min(λ + 10√λ + 30, 2000)`, which captures >99.999 % of probability mass for rates up to ~1000.
- `equiv_tfp_cls = tfd.Poisson` is set for TFP interoperability.

Fixes #164