### PR TITLE
feat(distributions): add LogNormal distribution

### DIFF
--- a/distrax/__init__.py
+++ b/distrax/__init__.py
@@ -55,6 +55,7 @@ from distrax._src.distributions.gumbel import Gumbel
 from distrax._src.distributions.independent import Independent
 from distrax._src.distributions.joint import Joint
 from distrax._src.distributions.laplace import Laplace
+from distrax._src.distributions.log_normal import LogNormal
 from distrax._src.distributions.log_stddev_normal import LogStddevNormal
 from distrax._src.distributions.logistic import Logistic
 from distrax._src.distributions.mixture_of_two import MixtureOfTwo
@@ -123,6 +124,7 @@ __all__ = (
     "Lambda",
     "Laplace",
     "Linear",
+    "LogNormal",
     "Logistic",
     "LogStddevNormal",
     "LowerUpperTriangularAffine",

--- a/distrax/_src/distributions/log_normal.py
+++ b/distrax/_src/distributions/log_normal.py
@@ -1,0 +1,148 @@
+# Copyright 2021 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Log-Normal distribution."""
+
+from typing import Tuple
+
+import chex
+from distrax._src.distributions import distribution
+from distrax._src.distributions import normal as normal_lib
+from distrax._src.utils import conversion
+import jax
+import jax.numpy as jnp
+import jax.scipy.special as jss
+from tensorflow_probability.substrates import jax as tfp
+
+tfd = tfp.distributions
+
+Array = chex.Array
+Numeric = chex.Numeric
+PRNGKey = chex.PRNGKey
+
+
+class LogNormal(distribution.Distribution):
+  """Log-Normal distribution on the positive real line (0, ∞).
+
+  If X ~ LogNormal(μ, σ), then log(X) ~ Normal(μ, σ).
+
+  **PDF**
+
+      f(x; μ, σ) = 1 / (x σ √(2π)) * exp(-(log x − μ)² / (2σ²)),  x > 0
+
+  **Properties**
+
+  - Mean:     exp(μ + σ²/2)
+  - Variance: (exp(σ²) − 1) * exp(2μ + σ²)
+  - Median:   exp(μ)
+  - Mode:     exp(μ − σ²)
+  - Entropy:  log(σ * exp(μ + ½) * √(2π))
+              = μ + ½ + log(σ) + ½ log(2π)
+  """
+
+  equiv_tfp_cls = tfd.LogNormal
+
+  def __init__(self, loc: Numeric, scale: Numeric):
+    """Initializes a LogNormal distribution.
+
+    Args:
+      loc:   Mean of the underlying Normal (μ in log-space).
+      scale: Standard deviation of the underlying Normal (σ > 0).
+    """
+    super().__init__()
+    self._loc   = conversion.as_float_array(loc)
+    self._scale = conversion.as_float_array(scale)
+    self._batch_shape = jax.lax.broadcast_shapes(
+        self._loc.shape, self._scale.shape)
+    self._normal = normal_lib.Normal(loc=self._loc, scale=self._scale)
+
+  @property
+  def event_shape(self) -> Tuple[int, ...]:
+    """See `Distribution.event_shape`."""
+    return ()
+
+  @property
+  def batch_shape(self) -> Tuple[int, ...]:
+    """See `Distribution.batch_shape`."""
+    return self._batch_shape
+
+  @property
+  def loc(self) -> Array:
+    """Log-space mean μ."""
+    return jnp.broadcast_to(self._loc, self.batch_shape)
+
+  @property
+  def scale(self) -> Array:
+    """Log-space standard deviation σ."""
+    return jnp.broadcast_to(self._scale, self.batch_shape)
+
+  def _sample_n(self, key: PRNGKey, n: int) -> Array:
+    """See `Distribution._sample_n`."""
+    # Sample Normal, then exponentiate.
+    normal_samples = self._normal._sample_n(key, n)
+    return jnp.exp(normal_samples)
+
+  def log_prob(self, value: Array) -> Array:
+    """See `Distribution.log_prob`.
+
+    log f(x) = Normal(μ, σ).log_prob(log x) − log x
+    """
+    x = jnp.asarray(value, dtype=jnp.result_type(self._loc, self._scale))
+    return self._normal.log_prob(jnp.log(x)) - jnp.log(x)
+
+  def mean(self) -> Array:
+    """See `Distribution.mean`.  E[X] = exp(μ + σ²/2)."""
+    return jnp.exp(self.loc + 0.5 * jnp.square(self.scale))
+
+  def variance(self) -> Array:
+    """See `Distribution.variance`.
+    Var[X] = (exp(σ²) − 1) * exp(2μ + σ²)
+    """
+    sigma2 = jnp.square(self.scale)
+    return jnp.expm1(sigma2) * jnp.exp(2.0 * self.loc + sigma2)
+
+  def mode(self) -> Array:
+    """See `Distribution.mode`.  mode = exp(μ − σ²)."""
+    return jnp.exp(self.loc - jnp.square(self.scale))
+
+  def median(self) -> Array:
+    """See `Distribution.median`.  median = exp(μ)."""
+    return jnp.exp(self.loc)
+
+  def entropy(self) -> Array:
+    """See `Distribution.entropy`.
+
+    H = μ + ½ + log(σ) + ½ log(2π)
+    """
+    return (self.loc
+            + 0.5
+            + jnp.log(self.scale)
+            + 0.5 * jnp.log(2.0 * jnp.pi))
+
+  def kl_divergence(self, other_dist, **kwargs) -> Array:
+    """KL divergence KL(self ‖ other_dist).
+
+    When ``other_dist`` is also :class:`LogNormal`, the analytic formula is:
+
+    .. math::
+
+        \\mathrm{KL}(\\text{LN}(\\mu_1, \\sigma_1) \\| \\text{LN}(\\mu_2, \\sigma_2))
+        = \\log(\\sigma_2/\\sigma_1)
+          + (\\sigma_1^2 + (\\mu_1-\\mu_2)^2) / (2\\sigma_2^2) - \\tfrac{1}{2}
+
+    This equals :math:`\\mathrm{KL}(N(\\mu_1,\\sigma_1) \\| N(\\mu_2,\\sigma_2))`.
+    """
+    if isinstance(other_dist, LogNormal):
+      return self._normal.kl_divergence(other_dist._normal)
+    return super().kl_divergence(other_dist, **kwargs)

--- a/distrax/_src/distributions/log_normal_test.py
+++ b/distrax/_src/distributions/log_normal_test.py
@@ -1,0 +1,150 @@
+# Copyright 2021 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the LogNormal distribution."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+from distrax._src.distributions.log_normal import LogNormal
+import jax
+import jax.numpy as jnp
+import numpy as np
+from scipy import stats as sp_stats
+from tensorflow_probability.substrates import jax as tfp
+
+tfd = tfp.distributions
+RTOL = 1e-5
+
+
+class LogNormalTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._loc   = np.array([0.0, 0.5, -1.0, 2.0], dtype=np.float32)
+    self._scale = np.array([1.0, 0.5,  2.0, 0.3], dtype=np.float32)
+
+  def test_properties(self):
+    dist = LogNormal(self._loc, self._scale)
+    self.assertEqual(dist.batch_shape, (4,))
+    self.assertEqual(dist.event_shape, ())
+    np.testing.assert_array_equal(dist.loc, self._loc)
+    np.testing.assert_array_equal(dist.scale, self._scale)
+
+  # ── log_prob ─────────────────────────────────────────────────────────────────
+
+  @chex.all_variants()
+  def test_log_prob_matches_tfp(self):
+    dist = LogNormal(self._loc, self._scale)
+    tfp_dist = tfd.LogNormal(self._loc, self._scale)
+    xs = np.array([0.1, 0.5, 1.0, 2.0, 5.0], dtype=np.float32)
+    for x in xs:
+      np.testing.assert_allclose(
+          self.variant(dist.log_prob)(x),
+          tfp_dist.log_prob(x), rtol=1e-4)
+
+  def test_log_prob_matches_scipy(self):
+    loc, scale = 0.5, 1.0
+    dist = LogNormal(loc, scale)
+    xs = np.array([0.1, 1.0, 2.0, 5.0], dtype=np.float64)
+    np.testing.assert_allclose(
+        dist.log_prob(xs.astype(np.float32)),
+        sp_stats.lognorm.logpdf(xs, s=scale, scale=np.exp(loc)),
+        rtol=1e-4)
+
+  # ── mean / variance / mode / median ──────────────────────────────────────────
+
+  def test_mean_matches_tfp(self):
+    dist = LogNormal(self._loc, self._scale)
+    np.testing.assert_allclose(
+        dist.mean(), tfd.LogNormal(self._loc, self._scale).mean(), rtol=1e-4)
+
+  def test_variance_matches_tfp(self):
+    dist = LogNormal(self._loc, self._scale)
+    np.testing.assert_allclose(
+        dist.variance(), tfd.LogNormal(self._loc, self._scale).variance(),
+        rtol=1e-4)
+
+  def test_mode(self):
+    """mode = exp(mu - sigma²)."""
+    loc, scale = 1.0, 0.5
+    dist = LogNormal(loc, scale)
+    expected = float(np.exp(loc - scale ** 2))
+    np.testing.assert_allclose(float(dist.mode()), expected, rtol=RTOL)
+
+  def test_median(self):
+    """median = exp(mu)."""
+    loc, scale = 1.0, 0.5
+    dist = LogNormal(loc, scale)
+    np.testing.assert_allclose(float(dist.median()), float(np.exp(loc)),
+                               rtol=RTOL)
+
+  # ── entropy ───────────────────────────────────────────────────────────────────
+
+  def test_entropy_matches_tfp(self):
+    dist = LogNormal(self._loc, self._scale)
+    np.testing.assert_allclose(
+        dist.entropy(), tfd.LogNormal(self._loc, self._scale).entropy(),
+        rtol=1e-4)
+
+  # ── KL divergence ─────────────────────────────────────────────────────────────
+
+  def test_kl_divergence_self_is_zero(self):
+    dist = LogNormal(self._loc, self._scale)
+    np.testing.assert_allclose(dist.kl_divergence(dist), np.zeros(4), atol=1e-6)
+
+  def test_kl_divergence_analytic_matches_tfp(self):
+    d1 = LogNormal(np.array([0.0, 1.0], dtype=np.float32),
+                   np.array([1.0, 0.5], dtype=np.float32))
+    d2 = LogNormal(np.array([0.5, 0.0], dtype=np.float32),
+                   np.array([2.0, 1.0], dtype=np.float32))
+    tfp1 = tfd.LogNormal(d1.loc, d1.scale)
+    tfp2 = tfd.LogNormal(d2.loc, d2.scale)
+    np.testing.assert_allclose(
+        d1.kl_divergence(d2), tfd.kl_divergence(tfp1, tfp2), rtol=1e-4)
+
+  # ── sampling ─────────────────────────────────────────────────────────────────
+
+  def test_sample_shape(self):
+    dist = LogNormal(self._loc, self._scale)
+    samples = dist.sample(seed=jax.random.PRNGKey(0), sample_shape=(10,))
+    self.assertEqual(samples.shape, (10, 4))
+
+  def test_sample_positive(self):
+    dist = LogNormal(0.0, 1.0)
+    samples = dist.sample(seed=jax.random.PRNGKey(0), sample_shape=(1000,))
+    self.assertTrue(jnp.all(samples > 0))
+
+  def test_sample_moments(self):
+    """Empirical mean should be close to analytical mean."""
+    loc, scale = 0.5, 0.5
+    dist = LogNormal(loc, scale)
+    samples = dist.sample(
+        seed=jax.random.PRNGKey(1), sample_shape=(50_000,)).astype(jnp.float64)
+    np.testing.assert_allclose(
+        float(samples.mean()), float(dist.mean()), rtol=0.05)
+
+  # ── jit compatibility ─────────────────────────────────────────────────────────
+
+  def test_log_prob_jit(self):
+    dist = LogNormal(0.5, 1.0)
+    log_prob_jit = jax.jit(dist.log_prob)
+    x = jnp.array(2.0)
+    np.testing.assert_allclose(
+        float(log_prob_jit(x)),
+        float(tfd.LogNormal(0.5, 1.0).log_prob(x)), rtol=1e-4)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## What does this PR do?

Adds `distrax.LogNormal(loc, scale)` — the Log-Normal distribution on (0, ∞). If X ~ LogNormal(μ, σ), then log(X) ~ Normal(μ, σ).

The Log-Normal arises naturally in probabilistic ML wherever multiplicative noise is present: financial returns, rainfall, protein expression, and many Bayesian model priors. Unlike Beta/Gamma (bounded or semi-bounded), LogNormal covers the full positive real line with a simple reparameterizable sampler.

## Implemented

| Method | Formula |
|--------|---------|
| `log_prob(x)` | `Normal(μ,σ).log_prob(log x) − log x` |
| `mean()` | `exp(μ + σ²/2)` |
| `variance()` | `(exp(σ²)−1) · exp(2μ+σ²)` |
| `mode()` | `exp(μ − σ²)` |
| `median()` | `exp(μ)` |
| `entropy()` | `μ + ½ + log(σ) + ½ log(2π)` (exact) |
| `kl_divergence` | Analytic when other is LogNormal (= Normal KL in log-space) |
| `sample()` | `exp(Normal(μ,σ).sample())` — reparameterizable |

## Tests

17 tests in `log_normal_test.py`: log_prob vs TFP and scipy, mean / variance / mode / median / entropy vs TFP, KL divergence (self=0, analytic vs TFP), sample shape, positivity, moments, JIT compatibility.