### PR TITLE
Fix AOT compilation with donated Jittable arguments

### DIFF
--- a/distrax/_src/utils/jittable.py
+++ b/distrax/_src/utils/jittable.py
@@ -56,8 +56,8 @@ class Jittable(metaclass=abc.ABCMeta):
 
 def _is_jax_data(x):
   """Check whether `x` is an instance of a JAX-compatible type."""
-  # If it's a tracer, then it's already been converted by JAX.
-  if isinstance(x, jax.core.Tracer):
+  # Tracers and AOT input descriptors have already been converted by JAX.
+  if isinstance(x, (jax.core.Tracer, jax.stages.ArgInfo)):
     return True
 
   # `jax.vmap` replaces vmappable leaves with `object()` during serialization.

--- a/distrax/_src/utils/jittable_test.py
+++ b/distrax/_src/utils/jittable_test.py
@@ -94,6 +94,17 @@ class JittableTest(parameterized.TestCase):
       add_one_to_params(DummyJittable(jnp.zeros((5,))))
       add_one_to_params(DummyJittable(jnp.ones((5,))))
 
+  def test_donatable_to_aot_compiled_function(self):
+    def get_params(obj):
+      return obj.data['params']
+
+    obj = DummyJittable(jnp.ones((5,)))
+    compiled = (
+        jax.jit(get_params, donate_argnums=0).trace(obj).lower().compile()
+    )
+
+    np.testing.assert_array_equal(compiled(obj), jnp.ones((5,)))
+
   def test_modifying_object_data_does_not_leak_tracers(self):
     @jax.jit
     def add_one_to_params(obj):


### PR DESCRIPTION
## Summary

Treat `jax.stages.ArgInfo` placeholders as dynamic JAX data when flattening Distrax `Jittable` objects.

During ahead-of-time staging with `donate_argnums`, JAX replaces donated array leaves with `ArgInfo` descriptors. Distrax currently classifies those descriptors as static metadata, so the compiled input pytree records different auxiliary data from the runtime distribution and rejects the call.

Keeping `ArgInfo` in the dynamic children preserves a stable pytree definition between tracing and compiled invocation. The regression test covers the complete `trace(...).lower().compile()` path with a donated `Jittable` argument.

Fixes #308.

## Testing

- `python -m pytest distrax/_src/utils/jittable_test.py -q` with JAX 0.7.2: 7 passed
- Same focused suite with JAX 0.10.1: 7 passed
- Original `Categorical` AOT donation reproduction with JAX 0.10.1
- `python -m ruff check --no-cache distrax/_src/utils/jittable.py distrax/_src/utils/jittable_test.py`
- `git diff --check`

The full Windows suite was attempted but stalled in parallel JAX workers without reporting a test failure; GitHub CI is the authoritative full-suite run.