### PR TITLE
Avoid intermediate NaN in `multiply_no_nan`.

### DIFF
--- a/distrax/_src/utils/math.py
+++ b/distrax/_src/utils/math.py
@@ -43,7 +43,11 @@ def multiply_no_nan(x: Array, y: Array) -> Array:
     ValueError if the shapes of `x` and `y` do not match.
   """
   dtype = jnp.result_type(x, y)
-  return jnp.where(y == 0, jnp.zeros((), dtype=dtype), x * y)
+  # Replace `x` with zero where `y` is zero before multiplying, so that `0 * y`
+  # is computed instead of `x * 0`. This avoids producing an intermediate NaN
+  # when `x` is infinite and `y` is zero, which would be detected by
+  # `checkify`'s NaN checks even though the result is correct.
+  return jnp.where(y == 0, jnp.zeros((), dtype=dtype), x) * y
 
 
 # TODO(dougalm): move helpers like these into JAX AD utils

--- a/distrax/_src/utils/math_test.py
+++ b/distrax/_src/utils/math_test.py
@@ -39,6 +39,18 @@ class MathTest(absltest.TestCase):
         lambda inputs: math.multiply_no_nan(inputs[0], inputs[1]))
     np.testing.assert_allclose(grad_fn((x, y)), (y, x), rtol=1e-3)
 
+  def test_multiply_no_nan_checkify(self):
+    """`multiply_no_nan` should not trigger checkify's NaN checks."""
+    from jax.experimental import checkify
+
+    def f(x, y):
+      return math.multiply_no_nan(x, y)
+
+    checked_f = checkify.checkify(f, errors=checkify.nan_checks)
+    err, out = checked_f(-jnp.inf, jnp.zeros(()))
+    err.throw()  # Raises if a NaN check was triggered.
+    self.assertEqual(out, 0.)
+
   def test_power_no_nan(self):
     zero = jnp.zeros(())
     nan = zero / zero


### PR DESCRIPTION
## Problem

`math.multiply_no_nan(x, y)` is meant to return 0 when `y == 0`, even if `x` is NaN or infinite. The previous implementation computed

```python
jnp.where(y == 0, jnp.zeros((), dtype=dtype), x * y)
```

which eagerly evaluates `x * y` for every element. When `x` is infinite and `y` is zero, `inf * 0` produces an intermediate NaN that `jnp.where` then masks out. The result is numerically correct, but the intermediate NaN is still observed by `checkify`'s NaN checks, so enabling `checkify.nan_checks` on code that calls `multiply_no_nan` (e.g. `Categorical.log_prob` when some probabilities are zero) raises a spurious `JaxRuntimeError` (see #187).

## Fix

Zero out `x` where `y == 0` *before* multiplying, so `0 * y` is computed instead of `x * 0`:

```python
jnp.where(y == 0, jnp.zeros((), dtype=dtype), x) * y
```

This produces identical results and gradients (the custom JVP is unchanged), but never materializes the NaN.

## Test

Added `test_multiply_no_nan_checkify`, which wraps `multiply_no_nan(-inf, 0)` in `checkify.checkify(..., errors=checkify.nan_checks)` and asserts no NaN check is triggered. This test fails on the previous implementation and passes after the fix. Existing `test_multiply_no_nan` and `test_multiply_no_nan_grads` still pass.